### PR TITLE
Garison multiple buildings on larger groups

### DIFF
--- a/@AresModAchillesExpansion/addons/modules_f_ares/Behaviours/functions/fn_GarrisonNearest.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Behaviours/functions/fn_GarrisonNearest.sqf
@@ -15,7 +15,12 @@ if (_doesGroupContainAnyPlayer) then
 }
 else
 {
-	[(getPos _logic), (units _groupUnderCursor), 150, true, false] call Ares_fnc_ZenOccupyHouse;
+	_unitCount = count (units _groupUnderCursor);
+	if (_unitCount >= 8) then {
+		[(getPos _logic), (units _groupUnderCursor), 150, true, true] call Ares_fnc_ZenOccupyHouse;
+	} else {
+		[(getPos _logic), (units _groupUnderCursor), 150, true, false] call Ares_fnc_ZenOccupyHouse;
+	}
 	[objnull, "Garrisoned nearest building."] call bis_fnc_showCuratorFeedbackMessage;
 };
 


### PR DESCRIPTION
Currently the Garrison function will take a group of AI, searches for the closest building with a 150m radius and tries to place them all inside this (single) building.

For smaller AI groups this works fine, but for larger groups (eg. 8+ units) this might cause some funny situations, especially in a more urban environment, where a whole group just hunkers down in a single building while half of the units don't have any sight.

I would suggest to modify the Garrison Building function to make it a bit more flexible:

- If the AI group size is 8 units or larger, spread the units among all buildings within the radius
- If the AI group size is 7 units or smaller, place all the units in the closest building (within the radius)