### PR TITLE
Updated ACE Heal for better compatability

### DIFF
--- a/@AresModAchillesExpansion/addons/modules_f_achilles/ACE/functions/fn_ModuleACEHeal.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/ACE/functions/fn_ModuleACEHeal.sqf
@@ -17,7 +17,7 @@ _mode = if (!isNull _unit) then {"single"} else {"multiple"};
 
 _options = [localize "STR_RANDOM",localize "STR_NONE_INJURY",localize "STR_LIGHT_INJURY", localize "STR_SEVERE"];
 
-if (isClass (configfile >> "CfgPatches" >> "ace_main")) then
+if (isClass (configfile >> "CfgPatches" >> "ace_medical")) then
 {
 	if (_mode == "single") then
 	{


### PR DESCRIPTION
You can remove certain ACE3 PBOs and this change would better work if a player removed their ACE3 medical PBO.