### PR TITLE
Fix weapons not being removed when Pylon Loadout is changed

### DIFF
--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changePylonAmmo.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changePylonAmmo.sqf
@@ -43,6 +43,7 @@ _curatorSelected = _curatorSelected select {_x isKindOf _planeType};
 
 {
 	_plane = _x;
+	{ _plane removeWeaponGlobal getText (configFile >> "CfgMagazines" >> _x >> "pylonWeapon") } forEach _allCurrentPylonMagazines;
 	{
 		private _magIndex = _x;
 		private _pylonIndex = _forEachIndex + 1;

--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/common/fn_setVehicleAmmoDef.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/common/fn_setVehicleAmmoDef.sqf
@@ -19,8 +19,6 @@
 
 params ["_vehicle",["_percentage",1,[1]]];
 
-hint "Achilles VehicleAmmoDef is being called.";
-
 _pylonMags = getPylonMagazines _vehicle;
 if (count _pylonMags == 0) then { //Changing Pylon Loadouts and calling setVehicleAmmoDef can cause problems.
 	_vehicle setVehicleAmmoDef _percentage;

--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/common/fn_setVehicleAmmoDef.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/common/fn_setVehicleAmmoDef.sqf
@@ -19,13 +19,16 @@
 
 params ["_vehicle",["_percentage",1,[1]]];
 
+hint "Achilles VehicleAmmoDef is being called.";
+
 _pylonMags = getPylonMagazines _vehicle;
-_vehicle setVehicleAmmoDef _percentage;
+if (count _pylonMags == 0) then { //Changing Pylon Loadouts and calling setVehicleAmmoDef can cause problems.
+	_vehicle setVehicleAmmoDef _percentage;
+} else {
+	_vehicle setVehicleAmmo _percentage;
+};
 {
 	private _cfg_ammoCount = getNumber (configfile >> "CfgMagazines" >> _x >> "count");
 	_vehicle setPylonLoadOut [_forEachIndex + 1, _x];
 	_vehicle setAmmoOnPylon [_forEachIndex + 1, round (_cfg_ammoCount * _percentage)];	
 } forEach _pylonMags;
-
-
-


### PR DESCRIPTION
This fix prevents weapons that are no longer attached to pylons from showing up in the weapon selection. Before, changing pylon weapons would keep the old weapons, and the pilot would have to cycle through them.